### PR TITLE
Table of Contents prototype

### DIFF
--- a/pandoc-template.html
+++ b/pandoc-template.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta name="generator" content="pandoc" />
+$for(author-meta)$
+  <meta name="author" content="$author-meta$" />
+$endfor$
+$if(date-meta)$
+  <meta name="date" content="$date-meta$" />
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
+  <style type="text/css">code{white-space: pre;}</style>
+$if(quotes)$
+  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+$endif$
+$if(highlighting-css)$
+  <style type="text/css">
+$highlighting-css$
+  </style>
+$endif$
+$for(css)$
+  <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+$endfor$
+$if(math)$
+  $math$
+$endif$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<div id="$idprefix$header">
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<h1 class="subtitle">$subtitle$</h1>
+$endif$
+$for(author)$
+<h2 class="author">$author$</h2>
+$endfor$
+$if(date)$
+<h3 class="date">$date$</h3>
+$endif$
+</div>
+$endif$
+$if(toc)$
+<nav id="$idprefix$toc">
+$toc$
+</nav>
+$endif$
+<main>
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</main>
+</body>
+</html>

--- a/showdown.vala
+++ b/showdown.vala
@@ -129,6 +129,9 @@ class Window: Gtk.ApplicationWindow {
                 "pandoc", // TODO: Make this configurable
                 "-f", "markdown",
                 "-t", "html5",
+                "--template", "pandoc-template.html",
+                "--toc",
+                // "--toc-depth", "2",
                 filename,
                 null
             };
@@ -148,7 +151,6 @@ class Window: Gtk.ApplicationWindow {
                 var html = document_template.printf(
                     "TODO: Page Title",
                     default_stylesheet,
-                    "TODO: Table of Contents",
                     output
                 );
                 webview.load_html(html, file.get_uri());

--- a/template.html
+++ b/template.html
@@ -6,11 +6,6 @@
     <style>%s</style>
 </head>
 <body>
-    <nav id="toc">
-        %s
-    </nav>
-    <main>
-        %s
-    </main>
+    %s
 </body>
 </html>


### PR DESCRIPTION
A prototype of how to create Pandoc generated Table of Contents in Showdown.

1. `pandoc-template.html` is the default pandoc HTML template modified to control the output of the generated HTML by adding [a custom id of `#toc` to `nav` tag](https://github.com/craigbarnes/showdown/compare/vala...xHN35RQ:vala?expand=1#diff-0e57270ec261c8fbbc99598b51d82caeR51) and also adding [`main` tags to the output](https://github.com/craigbarnes/showdown/compare/vala...xHN35RQ:vala?expand=1#diff-0e57270ec261c8fbbc99598b51d82caeR56).

2. We control the generation of the Table of Contents by [passing `--template` and `--toc` args](https://github.com/craigbarnes/showdown/compare/vala...xHN35RQ:vala?expand=1#diff-b0f25372792dd470a6db5c1c1c7deecbR132). We can also [pass `--toc-depth`](https://github.com/craigbarnes/showdown/compare/vala...xHN35RQ:vala?expand=1#diff-b0f25372792dd470a6db5c1c1c7deecbR134) to control the level of headers pandoc will include in the Table of Contents. By default all headers are included.

3. It was necessary to move the `nav` and `main` tags into `pandoc-template.html` since pandoc outputs the entire document in one pass. You cannot (as far as I'm aware) selectively generate specific portions of the input document. So instead we let pandoc add the `nav` and `main` tags and then just [push the entire document into the main template](https://github.com/craigbarnes/showdown/compare/vala...xHN35RQ:vala?expand=1#diff-708f92ebeb538db90b0e25f9157e9d2eL9).

I'm not sure I'm using Showdown's templates appropriately. Hopefully this prototype helps spark some ideas. Thanks again! :cake: 