### PR TITLE
Flatpak command: install for user only

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installing
 
 The easiest way to install Showdown is via [Flatpak] (0.8+), using the command:
 
-    flatpak install https://craigbarnes.gitlab.io/showdown/showdown.flatpakref
+    flatpak install --user https://craigbarnes.gitlab.io/showdown/showdown.flatpakref
 
 Building
 --------


### PR DESCRIPTION
The command does not work without sudo or --user on some distro. So i added the --user parameter.

Otherwise on Debian: 

    error: fsetxattr(user.ostreemeta) operation not supported