### PR TITLE
Implement ToC links handling workaround

### DIFF
--- a/src/view.vala
+++ b/src/view.vala
@@ -19,11 +19,9 @@ class Showdown.MarkdownView: WebKit.WebView {
             user_content_manager.add_style_sheet(user_stylesheet);
         }
         if (user_script != null) {
-            settings.enable_javascript = true;
             user_content_manager.add_script(user_script);
-        } else {
-            settings.enable_javascript = false;
         }
+        settings.enable_javascript = true;
     }
 
     internal static void load_user_assets() {
@@ -76,6 +74,17 @@ class Showdown.MarkdownView: WebKit.WebView {
                 }
             }
             decision.ignore();
+            return false;
+        }else if (type == PolicyDecisionType.NAVIGATION_ACTION) {
+            var d = decision as NavigationPolicyDecision;
+            var uri = d.get_navigation_action().get_request().get_uri();
+            var pos = uri.index_of_char('#');
+            if(pos != -1){
+                var anchor = uri.substring(pos+1);
+                var script = "document.getElementById(\"".concat(anchor,"\").scrollIntoView();"); //script from https://stackoverflow.com/a/13736194
+                run_javascript(script, null);
+            }
+            d.use();
             return false;
         }
         return true;


### PR DESCRIPTION
Implements a workaround for the bug described in #41.
It's a quite nasty hack, and requires javascript to be turned on all the time (not only when there are user-loaded scripts). It basically injects some code into the page every time a link with anchor is clicked.
Tested on Ubuntu 17.10
libwebkit2gtk-4.0-37 version: 2.18.6

